### PR TITLE
Fix unable to install agent on Windows OS(later than XP) with any password

### DIFF
--- a/installer_script.nsi
+++ b/installer_script.nsi
@@ -47,7 +47,7 @@
 !define SERVICE_NAME "ProActiveAgent"
 !define SERVICE_DESC "The ProActive Agent enables desktop computers as an important source of computational power"
 
-BrandingText "(C) 2016 INRIA/ActiveEon"
+BrandingText "(C) 2017 INRIA/ActiveEon"
 
 VIProductVersion                 "${VERSION}.0"
 VIAddVersionKey ProductName      "${PRODUCT_NAME}"
@@ -58,7 +58,7 @@ VIAddVersionKey FileDescription  "Installer of the ProActive Agent ${VERSION} ${
 VIAddVersionKey FileVersion      ${VERSION}
 VIAddVersionKey ProductVersion   ${VERSION}
 VIAddVersionKey InternalName     "ProActiveAgent"
-VIAddVersionKey LegalTrademarks  "Copyright (C) Activeeon 2016"
+VIAddVersionKey LegalTrademarks  "Copyright (C) Activeeon 2017"
 VIAddVersionKey OriginalFilename "ProActiveAgent-${VERSION}${FILENAME_SUFFIX}-setup.exe"
 
 #################################################################
@@ -837,7 +837,8 @@ Section "ProActive Agent"
         ${EndIf}
         !insertmacro Log "Encrypting password ..."
         StrCpy $0 $AccountPassword ; copy register to stack
-        System::Call "pacrypt::encryptData(w, w) i(r0., .r1).r2"
+        StrCpy $3 ${INSTALL_LOG_PATH} ; copy logFilePath to stack
+        System::Call "pacrypt::encryptDataWithLog(w, w, w) i(r0., .r1, r3.).r2"
         ${If} $2 != 0
            !insertmacro Log "!! Unable to encrypt the password (too long ?). Error $2 !!"
            MessageBox MB_OK "Unable to encrypt the password (too long ?). Error $2" /SD IDOK

--- a/installer_script.nsi
+++ b/installer_script.nsi
@@ -826,10 +826,11 @@ Section "ProActive Agent"
 
         ; Encrypt the password, see AGENT-154
         File "bin\Release\pacrypt.dll" ; the .dll contains C-Signature: int encryptData(wchar_t *input, wchar_t *output)
+        ;Load pacrypt.dll for encryption to the OS memory and check if it is loaded successfully
         !insertmacro Log "Loading pacrypt.dll"
         System::Call 'KERNEL32::LoadLibrary(t "$INSTDIR\pacrypt.dll")i.r3' ;directly load the library that is needed for encryption
-        System::Call "KERNEL32::GetModuleHandle(t 'pacrypt.dll') i.r0"
-        ${If} $0 == 0
+        System::Call "KERNEL32::GetModuleHandle(t 'pacrypt.dll') i.r0"     ;check if the pacrypt.dll was loaded, the result is written in 0 register
+        ${If} $0 == 0 ;check if pacrypt.dll was loaded successfully, in this case in 0 register should be non zero value
            !insertmacro Log "!! Unable to load pacrypt.dll file for encryption !!"
            MessageBox MB_OK "Unable to load pacrypt.dll file for encryption" /SD IDOK
            Call RollbackIfSilent

--- a/utils/pacrypt/WinAES.cpp
+++ b/utils/pacrypt/WinAES.cpp
@@ -809,7 +809,7 @@ void bytearray_to_wstring(std::wstring &dst, const unsigned char *src, const int
 
 DllExport int encryptDataStd(const std::wstring &inputData, std::wstring &outputDataInHex)
 {
-    cout << "Encrypt data with WinAES" << endl;
+	cout << "Encrypt data with WinAES" << endl;
 	int status = 0;	
 	WinAES aes;
 
@@ -957,35 +957,35 @@ extern "C" {
 	}
 
 	DllExport int encryptDataWithLog(const wchar_t *inputData, wchar_t *outputDataInHex, wchar_t *logFile){
-        std::wstring logFilePath(logFile);
-        std::string logFilePathStr(logFilePath.begin(), logFilePath.end());
+		std::wstring logFilePath(logFile);
+		std::string logFilePathStr(logFilePath.begin(), logFilePath.end());
 
-        std::streambuf *coutbuf = std::cout.rdbuf(); //save old buf
-        std::streambuf *cerrbuf = std::cerr.rdbuf(); //save old buf
+		std::streambuf *coutbuf = std::cout.rdbuf(); //save old buf
+		std::streambuf *cerrbuf = std::cerr.rdbuf(); //save old buf
 		std::ofstream myfile;
 		int res;
-        try
-        {
-            myfile.open(logFilePathStr, std::ios_base::app);
-            if (myfile.is_open()) {
-
-                 //redirection cout, cerr streams to file
-                std::cout.rdbuf(myfile.rdbuf()); //redirect std::cout to logFile
-                std::cerr.rdbuf(myfile.rdbuf()); //redirect std::cerr to logFile
-            }
-            else cerr << "Unable to open log file: " + logFilePathStr << endl;
-
-            // Encrypt input data
-            res = encryptData(inputData, outputDataInHex);
-
-            std::cout.rdbuf(coutbuf); //reset to standard output again
-            std::cerr.rdbuf(cerrbuf); //reset to standard error output again
-        }
+		try
+		{
+			myfile.open(logFilePathStr, std::ios_base::app);
+			if (myfile.is_open()) {
+			
+				//redirection cout, cerr streams to file
+				std::cout.rdbuf(myfile.rdbuf()); //redirect std::cout to logFile
+				std::cerr.rdbuf(myfile.rdbuf()); //redirect std::cerr to logFile
+			}
+			else cerr << "Unable to open log file: " + logFilePathStr << endl;
+			
+			// Encrypt input data
+			res = encryptData(inputData, outputDataInHex);
+			
+			std::cout.rdbuf(coutbuf); //reset to standard output again
+			std::cerr.rdbuf(cerrbuf); //reset to standard error output again
+		}
 		catch(std::ofstream::failure &writeErr)
-        {
-            myfile << "Error while writing to log file: " << writeErr.what() << endl;
-        }
-        myfile.close();
+		{
+			myfile << "Error while writing to log file: " << writeErr.what() << endl;
+		}
+		myfile.close();
 
 		return res;
 	}

--- a/utils/pacrypt/WinAES.cpp
+++ b/utils/pacrypt/WinAES.cpp
@@ -809,6 +809,7 @@ void bytearray_to_wstring(std::wstring &dst, const unsigned char *src, const int
 
 DllExport int encryptDataStd(const std::wstring &inputData, std::wstring &outputDataInHex)
 {
+    cout << "Encrypt data with WinAES" << endl;
 	int status = 0;	
 	WinAES aes;
 
@@ -949,8 +950,42 @@ extern "C" {
 		// Encrypt input data
 		const int res = encryptDataStd(input, output);
 
-		// Copy encrypted output into a cstring		
+		// Copy encrypted output into a cstring
 		wcscpy_s(outputDataInHex, output.length()+1, output.c_str());
+
+		return res;
+	}
+
+	DllExport int encryptDataWithLog(const wchar_t *inputData, wchar_t *outputDataInHex, wchar_t *logFile){
+        std::wstring logFilePath(logFile);
+        std::string logFilePathStr(logFilePath.begin(), logFilePath.end());
+
+        std::streambuf *coutbuf = std::cout.rdbuf(); //save old buf
+        std::streambuf *cerrbuf = std::cerr.rdbuf(); //save old buf
+		std::ofstream myfile;
+		int res;
+        try
+        {
+            myfile.open(logFilePathStr, std::ios_base::app);
+            if (myfile.is_open()) {
+
+                 //redirection cout, cerr streams to file
+                std::cout.rdbuf(myfile.rdbuf()); //redirect std::cout to logFile
+                std::cerr.rdbuf(myfile.rdbuf()); //redirect std::cerr to logFile
+            }
+            else cerr << "Unable to open log file: " + logFilePathStr << endl;
+
+            // Encrypt input data
+            res = encryptData(inputData, outputDataInHex);
+
+            std::cout.rdbuf(coutbuf); //reset to standard output again
+            std::cerr.rdbuf(cerrbuf); //reset to standard error output again
+        }
+		catch(std::ofstream::failure &writeErr)
+        {
+            myfile << "Error while writing to log file: " << writeErr.what() << endl;
+        }
+        myfile.close();
 
 		return res;
 	}

--- a/utils/pacrypt/WinAES.h
+++ b/utils/pacrypt/WinAES.h
@@ -195,7 +195,9 @@ extern "C" {
 	 * @param outputDataInHex encrypted data in hex format
 	 * @return 0 if no errors
 	 */
-	DllExport int encryptData(const wchar_t *inputData, wchar_t *outputDataInHex);
+	 DllExport int encryptData(const wchar_t *inputData, wchar_t *outputDataInHex);
+
+  	DllExport int encryptDataWithLog(const wchar_t *inputData, wchar_t *outputDataInHex, wchar_t *logFile);
 
 	/**
 	 * Decrypts previously encrypted data using Microsoft AES Cryptographic Service Provider


### PR DESCRIPTION
The issue that on any Windows OS later than Windows XP with any password was not possible to install Windows agent with next error message: "Unable to encrypt the password. Password too long?".

This closes #255 issue and in fact improve a fix of #249 issue (that was not fixing for any Windows OS ).
The solution of the PR is to explicitly load parcrypt.dll to memory and write properly the error messages to log file