### PR TITLE
fix for #253 : GUI editor is not loading JVM properties from PAAgent-config.xml

### DIFF
--- a/AgentForAgent/ConfigEditor.cs
+++ b/AgentForAgent/ConfigEditor.cs
@@ -95,7 +95,7 @@ namespace AgentForAgent
             else
             {
                 jvmDirectory.Text = conf.config.javaHome;
-            }
+            }          
 
             // Load the On Runtime Exit script absolute path
             this.scriptLocationTextBox.Text = conf.config.onRuntimeExitScript;
@@ -245,8 +245,8 @@ namespace AgentForAgent
             chart = new Chart();
             iniConfiguration = new IniFile(this.agentLocation + "\\configuration.ini");
 
-            this.internalSave(this.configurationLocation);
-            this.saveConfig.Enabled = false;
+            ConfigEditor_Load(null, null);
+            this.saveConfig.Enabled = true;
         }
 
         private void CreateEditBox(object sender)
@@ -1058,6 +1058,7 @@ namespace AgentForAgent
 
             if (this.configuration.config.jvmParameters != null)
             {
+                this.jvmOptionsListBox.Items.Clear();
                 this.jvmOptionsListBox.Items.AddRange(this.configuration.config.jvmParameters);
             }
         }


### PR DESCRIPTION
- Load the JVM options and show them in the list box when creating the GUI
- Clear the list box to avoid duplicates